### PR TITLE
fix: Make Packed Items child table read only

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -633,7 +633,8 @@
    "fieldtype": "Table",
    "label": "Packed Items",
    "options": "Packed Item",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only_depends_on": "eval: doc.__islocal"
   },
   {
    "fieldname": "product_bundle_help",
@@ -1607,7 +1608,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-04 22:22:31.471752",
+ "modified": "2025-11-16 15:25:53.929750",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -759,7 +759,8 @@
    "hide_seconds": 1,
    "label": "Packed Items",
    "options": "Packed Item",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only_depends_on": "eval: doc.__islocal"
   },
   {
    "fieldname": "product_bundle_help",
@@ -2251,7 +2252,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2025-10-09 14:48:59.472826",
+ "modified": "2025-11-16 15:24:06.023393",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1055,7 +1055,8 @@
    "hide_seconds": 1,
    "label": "Packed Items",
    "options": "Packed Item",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only_depends_on": "eval: doc.__islocal"
   },
   {
    "fieldname": "payment_schedule_section",
@@ -1703,7 +1704,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-12 12:14:29.760988",
+ "modified": "2025-11-16 15:42:40.632320",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -553,7 +553,8 @@
    "oldfieldname": "packing_details",
    "oldfieldtype": "Table",
    "options": "Packed Item",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only_depends_on": "eval: doc.__islocal"
   },
   {
    "fieldname": "product_bundle_help",
@@ -1424,7 +1425,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-04 19:20:47.724218",
+ "modified": "2025-11-16 15:25:08.893374",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",


### PR DESCRIPTION
**Issue:** Delivery Note packed items Serial Numbers Reset After Save / Draft Required

**Ref**: [47854](https://support.frappe.io/helpdesk/tickets/47854)

**Description:**
When a Sales Order is submitted and we create a Delivery Note from it, the Serial No. and Batch No. entered in the Packed Items table are getting reset after saving the document.
To resolve this issue, the fields are now marked as read-only before saving (i.e., in a new or unsaved document). After the document is saved, the Serial No. and Batch No. fields can be updated.

This same behavior is applied to other doctypes as well, such as POS Invoice, Sales Invoice, Sales Order, and Delivery Note.

**Before:**

[before-save-so.webm](https://github.com/user-attachments/assets/ac4fa5e6-24f2-4794-b235-fcfa63ac8f31)

**After:**

[after-save-so.webm](https://github.com/user-attachments/assets/f24a79c8-23c4-4ffd-be54-4c67f89c1aa5)

Backport Needed: v15
