### PR TITLE
chore: upgrade plaid-python from 7.2.1 to 39.2.0

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -34,6 +34,7 @@
   "integration_details_section",
   "integration_id",
   "last_integration_date",
+  "plaid_sync_cursor",
   "column_break_27",
   "mask"
  ],
@@ -217,6 +218,14 @@
    "fieldname": "is_credit_card",
    "fieldtype": "Check",
    "label": "Is Credit Card"
+  },
+  {
+   "fieldname": "plaid_sync_cursor",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Plaid Sync Cursor",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -262,7 +271,7 @@
    "link_fieldname": "default_bank_account"
   }
  ],
- "modified": "2026-04-11 19:46:27.609994",
+ "modified": "2026-05-27 17:23:54.989447",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account",

--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -41,6 +41,7 @@ class BankAccount(Document):
 		mask: DF.Data | None
 		party: DF.DynamicLink | None
 		party_type: DF.Link | None
+		plaid_sync_cursor: DF.LongText | None
 	# end: auto-generated types
 
 	def onload(self):

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
@@ -4,7 +4,65 @@
 import frappe
 import plaid
 from frappe import _
-from plaid.errors import APIError, InvalidRequestError, ItemError
+from plaid.api import plaid_api
+from plaid.model.country_code import CountryCode
+from plaid.model.item_public_token_exchange_request import ItemPublicTokenExchangeRequest
+from plaid.model.link_token_create_request import LinkTokenCreateRequest
+from plaid.model.link_token_create_request_user import LinkTokenCreateRequestUser
+from plaid.model.link_token_transactions import LinkTokenTransactions
+from plaid.model.products import Products
+from plaid.model.transactions_sync_request import TransactionsSyncRequest
+from plaid.model.transactions_sync_request_options import TransactionsSyncRequestOptions
+
+PLAID_ENVIRONMENT_HOSTS = {
+	"sandbox": plaid.Environment.Sandbox,
+	"production": plaid.Environment.Production,
+	# Development was removed from the SDK but is still a Plaid Settings option.
+	"development": "https://development.plaid.com",
+}
+
+PLAID_SUPPORTED_COUNTRY_CODES = [
+	"US",
+	"GB",
+	"ES",
+	"NL",
+	"FR",
+	"IE",
+	"CA",
+	"DE",
+	"IT",
+	"PL",
+	"DK",
+	"NO",
+	"SE",
+	"EE",
+	"LT",
+	"LV",
+	"PT",
+	"BE",
+	"AT",
+	"FI",
+]
+
+PLAID_SUPPORTED_LANGUAGE_CODES = {
+	"da",
+	"nl",
+	"en",
+	"et",
+	"fr",
+	"de",
+	"hi",
+	"it",
+	"lv",
+	"lt",
+	"no",
+	"pl",
+	"pt",
+	"ro",
+	"es",
+	"sv",
+	"vi",
+}
 
 
 class PlaidConnector:
@@ -13,76 +71,106 @@ class PlaidConnector:
 		self.settings = frappe.get_single("Plaid Settings")
 		self.products = ["transactions"]
 		self.client_name = frappe.local.site
-		self.client = plaid.Client(
-			client_id=self.settings.plaid_client_id,
-			secret=self.settings.get_password("plaid_secret"),
-			environment=self.settings.plaid_env,
-			api_version="2020-09-14",
+		self.client = self._get_client()
+
+	def _get_client(self):
+		configuration = plaid.Configuration(
+			host=PLAID_ENVIRONMENT_HOSTS.get(self.settings.plaid_env),
+			api_key={
+				"clientId": self.settings.plaid_client_id,
+				"secret": self.settings.get_password("plaid_secret"),
+				"plaidVersion": "2020-09-14",
+			},
 		)
+		api_client = plaid.ApiClient(configuration)
+		return plaid_api.PlaidApi(api_client)
+
+	@staticmethod
+	def _to_dict(obj):
+		if hasattr(obj, "to_dict"):
+			return obj.to_dict()
+		return obj
+
+	@staticmethod
+	def _get_link_language():
+		language = (frappe.local.lang or "en").split("-")[0].lower()
+		return language if language in PLAID_SUPPORTED_LANGUAGE_CODES else "en"
+
+	def get_transactions_days_requested(self):
+		days_requested = self.settings.transactions_days_requested or 90
+		return min(max(days_requested, 90), 730)
 
 	def get_access_token(self, public_token):
 		if public_token is None:
 			frappe.log_error("Plaid: Public token is missing")
-		response = self.client.Item.public_token.exchange(public_token)
-		access_token = response["access_token"]
-		return access_token
+
+		request = ItemPublicTokenExchangeRequest(public_token=public_token)
+		response = self.client.item_public_token_exchange(request)
+		return response.access_token
 
 	def get_token_request(self, update_mode=False):
 		country_codes = (
-			["US", "CA", "FR", "IE", "NL", "ES", "GB"]
-			if self.settings.enable_european_access
-			else ["US", "CA"]
+			PLAID_SUPPORTED_COUNTRY_CODES if self.settings.enable_european_access else ["US", "CA"]
 		)
-		args = {
+		request_kwargs = {
 			"client_name": self.client_name,
-			# only allow Plaid-supported languages and countries (LAST: Sep-19-2020)
-			"language": frappe.local.lang if frappe.local.lang in ["en", "fr", "es", "nl"] else "en",
-			"country_codes": country_codes,
-			"user": {"client_user_id": frappe.generate_hash(frappe.session.user, length=32)},
+			"language": self._get_link_language(),
+			"country_codes": [CountryCode(code) for code in country_codes],
+			"user": LinkTokenCreateRequestUser(
+				client_user_id=frappe.generate_hash(frappe.session.user, length=32)
+			),
 		}
 
 		if update_mode:
-			args["access_token"] = self.access_token
+			request_kwargs["access_token"] = self.access_token
 		else:
-			args.update(
-				{
-					"client_id": self.settings.plaid_client_id,
-					"secret": self.settings.plaid_secret,
-					"products": self.products,
-				}
+			request_kwargs["products"] = [Products(product) for product in self.products]
+			request_kwargs["transactions"] = LinkTokenTransactions(
+				days_requested=self.get_transactions_days_requested()
 			)
 
-		return args
+		return request_kwargs
 
 	def get_link_token(self, update_mode=False):
 		token_request = self.get_token_request(update_mode)
 
 		try:
-			response = self.client.LinkToken.create(token_request)
-		except InvalidRequestError:
-			frappe.log_error("Plaid: Invalid request error")
-			frappe.msgprint(_("Please check your Plaid client ID and secret values"))
-		except APIError as e:
-			frappe.log_error("Plaid: Authentication error")
-			frappe.throw(_(str(e)), title=_("Authentication Failed"))
+			response = self.client.link_token_create(LinkTokenCreateRequest(**token_request))
+		except plaid.ApiException as e:
+			frappe.log_error(message=e.body, title=_("Plaid: Link token create error"))
+			frappe.throw(_("Cannot retrieve link token. Check Error Log for more information"))
 		else:
-			return response["link_token"]
+			return response.link_token
 
-	def get_transactions(self, start_date, end_date, account_id=None):
-		kwargs = dict(access_token=self.access_token, start_date=start_date, end_date=end_date)
+	def get_transactions(self, cursor=None, account_id=None):
+		options = TransactionsSyncRequestOptions()
 		if account_id:
-			kwargs.update(dict(account_ids=[account_id]))
+			options.account_id = account_id
+
+		updates = {"added": [], "modified": [], "removed": [], "next_cursor": None}
+		request_cursor = cursor
 
 		try:
-			response = self.client.Transactions.get(**kwargs)
-			transactions = response["transactions"]
-			while len(transactions) < response["total_transactions"]:
-				response = self.client.Transactions.get(
-					self.access_token, start_date=start_date, end_date=end_date, offset=len(transactions)
+			while True:
+				request = TransactionsSyncRequest(
+					access_token=self.access_token,
+					cursor=request_cursor,
+					count=500,
+					options=options,
 				)
-				transactions.extend(response["transactions"])
-			return transactions
-		except ItemError as e:
-			raise e
+				response = self.client.transactions_sync(request)
+				for key in ("added", "modified", "removed"):
+					updates[key].extend(self._to_dict(transaction) for transaction in response.get(key, []))
+				updates["next_cursor"] = response.get("next_cursor")
+
+				if not response.has_more:
+					break
+
+				request_cursor = response.next_cursor
+
+			return updates
+		except plaid.ApiException as e:
+			frappe.log_error(message=e.body, title=_("Plaid: Transactions sync error"))
+			frappe.throw(_("Cannot sync transactions. Check Error Log for more information"))
 		except Exception:
 			frappe.log_error("Plaid: Transactions sync error")

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js
@@ -11,6 +11,10 @@ frappe.ui.form.on("Plaid Settings", {
 	},
 
 	refresh: function (frm) {
+		if (!frm.doc.transactions_days_requested) {
+			frm.set_value("transactions_days_requested", 90);
+		}
+
 		if (frm.doc.enabled) {
 			frm.add_custom_button(__("Link a new bank account"), () => {
 				new erpnext.integrations.plaidLink(frm);
@@ -43,6 +47,12 @@ frappe.ui.form.on("Plaid Settings", {
 					},
 				});
 			}).addClass("btn-primary");
+		}
+	},
+
+	transactions_days_requested: function (frm) {
+		if (!frm.doc.transactions_days_requested) {
+			frm.set_value("transactions_days_requested", 90);
 		}
 	},
 });

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.json
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.json
@@ -13,7 +13,8 @@
   "plaid_secret",
   "column_break_7",
   "plaid_env",
-  "enable_european_access"
+  "enable_european_access",
+  "transactions_days_requested"
  ],
  "fields": [
   {
@@ -66,11 +67,18 @@
    "fieldname": "enable_european_access",
    "fieldtype": "Check",
    "label": "Enable European Access"
+  },
+  {
+   "default": "90",
+   "description": "Maximum number of days of transaction history to request for new Plaid links. Plaid defaults to 90 days and allows up to 730 days. Applies only to newly linked bank connections.",
+   "fieldname": "transactions_days_requested",
+   "fieldtype": "Int",
+   "label": "Transaction History Days"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:10:13.672028",
+ "modified": "2026-05-27 12:17:31.528441",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Plaid Settings",
@@ -87,6 +95,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -4,11 +4,11 @@
 import json
 
 import frappe
+import plaid
 from frappe import _
 from frappe.desk.doctype.tag.tag import add_tag
 from frappe.model.document import Document
-from frappe.utils import add_months, formatdate, getdate, sbool, today
-from plaid.errors import ItemError
+from frappe.utils import add_months, create_batch, formatdate, getdate, sbool, today
 
 from erpnext.erpnext_integrations.doctype.plaid_settings.plaid_connector import PlaidConnector
 
@@ -28,13 +28,20 @@ class PlaidSettings(Document):
 		plaid_client_id: DF.Data | None
 		plaid_env: DF.Literal["sandbox", "development", "production"]
 		plaid_secret: DF.Password | None
+		transactions_days_requested: DF.Int
 	# end: auto-generated types
+
+	def validate(self):
+		if not self.transactions_days_requested:
+			self.transactions_days_requested = 90
+		elif self.transactions_days_requested < 90 or self.transactions_days_requested > 730:
+			frappe.throw(_("Transaction History Days must be between 90 and 730."))
 
 	@staticmethod
 	@frappe.whitelist()
 	def get_link_token():
-		plaid = PlaidConnector()
-		return plaid.get_link_token()
+		plaid_connector = PlaidConnector()
+		return plaid_connector.get_link_token()
 
 
 @frappe.whitelist()
@@ -54,8 +61,8 @@ def get_plaid_configuration():
 def add_institution(token: str, response: str):
 	response = json.loads(response)
 
-	plaid = PlaidConnector()
-	access_token = plaid.get_access_token(token)
+	plaid_connector = PlaidConnector()
+	access_token = plaid_connector.get_access_token(token)
 	bank = None
 
 	if not frappe.db.exists("Bank", response["institution"]["name"]):
@@ -134,6 +141,7 @@ def add_bank_accounts(response: str | dict, bank: str | dict, company: str):
 						"account_subtype": account.get("subtype", ""),
 						"mask": account.get("mask", ""),
 						"integration_id": account["id"],
+						"plaid_sync_cursor": None,
 						"is_company_account": 1,
 						"company": company,
 					}
@@ -165,6 +173,7 @@ def add_bank_accounts(response: str | dict, bank: str | dict, company: str):
 						"account_subtype": account.get("subtype", ""),
 						"mask": account.get("mask", ""),
 						"integration_id": account["id"],
+						"plaid_sync_cursor": None,
 					}
 				)
 				existing_account.save()
@@ -206,14 +215,26 @@ def sync_transactions(bank, bank_account):
 	end_date = formatdate(today(), "YYYY-MM-dd")
 
 	try:
-		transactions = get_transactions(
-			bank=bank, bank_account=bank_account, start_date=start_date, end_date=end_date
-		)
+		updates = get_transactions(bank=bank, bank_account=bank_account)
+		transactions = updates.get("added", [])
 
 		result = []
 		if transactions:
 			for transaction in reversed(transactions):
 				result += new_bank_transaction(transaction)
+
+		if updates.get("next_cursor"):
+			frappe.db.set_value("Bank Account", bank_account, "plaid_sync_cursor", updates["next_cursor"])
+
+		if updates.get("modified"):
+			frappe.logger().info(
+				f"Plaid received {len(updates['modified'])} modified transactions for '{bank_account}'."
+			)
+
+		if updates.get("removed"):
+			frappe.logger().info(
+				f"Plaid received {len(updates['removed'])} removed transactions for '{bank_account}'."
+			)
 
 		if result:
 			last_transaction_date = frappe.db.get_value("Bank Transaction", result.pop(), "date")
@@ -227,31 +248,23 @@ def sync_transactions(bank, bank_account):
 		frappe.log_error(frappe.get_traceback(), _("Plaid transactions sync error"))
 
 
-def get_transactions(bank, bank_account=None, start_date=None, end_date=None):
-	access_token = None
-
+def get_transactions(bank, bank_account=None):
 	if bank_account:
 		related_bank = frappe.db.get_values(
-			"Bank Account", bank_account, ["bank", "integration_id"], as_dict=True
+			"Bank Account", bank_account, ["bank", "integration_id", "plaid_sync_cursor"], as_dict=True
 		)
-		access_token = frappe.db.get_value("Bank", related_bank[0].bank, "plaid_access_token")
-		account_id = related_bank[0].integration_id
+		bank_details = related_bank[0]
+		bank = bank_details.bank
+		account_id = bank_details.integration_id
+		cursor = bank_details.plaid_sync_cursor
 	else:
-		access_token = frappe.db.get_value("Bank", bank, "plaid_access_token")
 		account_id = None
+		cursor = None
 
-	plaid = PlaidConnector(access_token)
+	access_token = frappe.db.get_value("Bank", bank, "plaid_access_token")
 
-	transactions = []
-	try:
-		transactions = plaid.get_transactions(start_date=start_date, end_date=end_date, account_id=account_id)
-	except ItemError as e:
-		if e.code == "ITEM_LOGIN_REQUIRED":
-			msg = _("There was an error syncing transactions.") + " "
-			msg += _("Please refresh or reset the Plaid linking of the Bank {}.").format(bank) + " "
-			frappe.log_error(message=msg, title=_("Plaid Link Refresh Required"))
-
-	return transactions
+	plaid_connector = PlaidConnector(access_token)
+	return plaid_connector.get_transactions(cursor=cursor, account_id=account_id)
 
 
 def new_bank_transaction(transaction):
@@ -330,13 +343,16 @@ def enqueue_synchronization():
 			"erpnext.erpnext_integrations.doctype.plaid_settings.plaid_settings.sync_transactions",
 			bank=plaid_account.bank,
 			bank_account=plaid_account.name,
+			queue="long",
+			timeout=3600,
+			job_name=f"sync_plaid_transactions_{plaid_account.name}",
 		)
 
 
 @frappe.whitelist()
 def get_link_token_for_update(access_token: str):
-	plaid = PlaidConnector(access_token)
-	return plaid.get_link_token(update_mode=True)
+	plaid_connector = PlaidConnector(access_token)
+	return plaid_connector.get_link_token(update_mode=True)
 
 
 def get_company(bank_account_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 
     # integration dependencies
     "googlemaps~=4.10.0",
-    "plaid-python~=7.2.1",
+    "plaid-python~=39.2.0",
     "python-youtube~=0.9.8",
 
     # Not used directly - required by PyQRCode for PNG generation


### PR DESCRIPTION
Issue:

The current Plaid integration uses plaid-python v7.2.1 which relies on the deprecated plaid.Client initialization pattern and transactions/get endpoint. Plaid has since moved to a new SDK structure (plaid.Configuration / ApiClient) and recommends transactions/sync for incremental transaction fetching.