### PR TITLE
fix(stock): don't assign batch_no when a single batch can't fulfil the qty

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -325,27 +325,24 @@ def update_stock(ctx, out, doc=None):
 		if ctx.get("ignore_serial_nos"):
 			kwargs["ignore_serial_nos"] = ctx.get("ignore_serial_nos")
 
-		qty = out.stock_qty
-		batches = []
+		qty = flt(out.stock_qty)
 		if out.has_batch_no and not ctx.get("batch_no"):
-			batches = get_available_batches(kwargs)
+			batch_args = kwargs.copy()
+			batch_args.qty = 0
+			batches = get_available_batches(batch_args)
 			if doc:
 				filter_batches(batches, doc)
 
-			for batch_no, batch_qty in batches.items():
+			batch_no, batch_qty = next(iter(batches.items()), (None, 0))
+
+			if batch_no and flt(batch_qty) >= qty:
+				out.update({"batch_no": batch_no, "actual_batch_qty": qty})
+
 				rate = get_batch_based_item_price(
 					{"price_list": doc.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
 					out.item_code,
 				)
-				if batch_qty >= qty:
-					out.update({"batch_no": batch_no, "actual_batch_qty": qty})
-					if rate:
-						out.update({"rate": rate, "price_list_rate": rate})
-					break
-				else:
-					qty -= batch_qty
 
-				out.update({"batch_no": batch_no, "actual_batch_qty": batch_qty})
 				if rate:
 					out.update({"rate": rate, "price_list_rate": rate})
 

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import add_days
 
 from erpnext.stock.get_item_details import get_item_details
 from erpnext.tests.utils import ERPNextTestSuite
@@ -457,3 +458,137 @@ class TestGetItemDetail(ERPNextTestSuite):
 			frappe.set_user("Administrator")
 			frappe.db.set_single_value("Buying Settings", "maintain_same_rate", original)
 			frappe.clear_cache(doctype="Buying Settings")
+
+	def _setup_batch_item_with_stock(self, batches):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+
+		item = make_item(
+			properties={
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "FEFO-TAP-.#####",
+			},
+		)
+
+		for qty, expiry_date in batches:
+			se = make_stock_entry(
+				item_code=item.name,
+				target="_Test Warehouse - _TC",
+				qty=qty,
+				rate=100,
+				purpose="Material Receipt",
+			)
+			batch_no = se.items[0].batch_no or frappe.db.get_value(
+				"Serial and Batch Entry", {"parent": se.items[0].serial_and_batch_bundle}, "batch_no"
+			)
+			frappe.db.set_value("Batch", batch_no, "expiry_date", expiry_date)
+
+		return item.name
+
+	def _get_delivery_note_context(self, item_code, qty):
+		ctx = frappe._dict(
+			{
+				"item_code": item_code,
+				"doctype": "Delivery Note",
+				"warehouse": "_Test Warehouse - _TC",
+				"company": "_Test Company",
+				"qty": qty,
+				"stock_qty": qty,
+				"conversion_factor": 1,
+				"use_serial_batch_fields": 1,
+				"update_stock": 1,
+				"currency": "INR",
+				"conversion_rate": 1.0,
+				"price_list": "_Test Price List",
+				"price_list_currency": "INR",
+				"plc_conversion_rate": 1.0,
+				"transaction_date": None,
+				"name": None,
+				"ignore_pricing_rule": 1,
+			}
+		)
+		return ctx
+
+	def test_expiry_based_pick_spans_multiple_batches(self):
+		original_based_on = frappe.db.get_single_value("Stock Settings", "pick_serial_and_batch_based_on")
+		original_auto_create = frappe.db.get_single_value(
+			"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+		)
+		frappe.db.set_single_value("Stock Settings", "pick_serial_and_batch_based_on", "Expiry")
+		frappe.db.set_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", 1)
+
+		try:
+			item_code = self._setup_batch_item_with_stock(
+				[(2, add_days(None, 3)), (3, add_days(None, 9)), (14, add_days(None, 30))]
+			)
+
+			single_batch_details = get_item_details(
+				self._get_delivery_note_context(item_code, 2),
+				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
+			)
+			self.assertIsNotNone(single_batch_details.get("batch_no"))
+
+			next_batch_details = get_item_details(
+				self._get_delivery_note_context(item_code, 3),
+				doc={
+					"doctype": "Delivery Note",
+					"selling_price_list": "_Test Price List",
+					"items": [{"batch_no": single_batch_details.batch_no, "qty": 2}],
+				},
+			)
+			self.assertIsNotNone(next_batch_details.get("batch_no"))
+			self.assertNotEqual(
+				next_batch_details.batch_no,
+				single_batch_details.batch_no,
+			)
+
+			multiple_batch_details = get_item_details(
+				self._get_delivery_note_context(item_code, 5),
+				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
+			)
+			self.assertIsNone(multiple_batch_details.get("batch_no"))
+
+			insufficient_details = get_item_details(
+				self._get_delivery_note_context(item_code, 20),
+				doc={"doctype": "Delivery Note", "selling_price_list": "_Test Price List", "items": []},
+			)
+			self.assertIsNone(insufficient_details.get("batch_no"))
+
+			dn = frappe.get_doc(
+				{
+					"doctype": "Delivery Note",
+					"customer": "_Test Customer",
+					"company": "_Test Company",
+					"selling_price_list": "_Test Price List",
+					"currency": "INR",
+					"items": [
+						{
+							"item_code": item_code,
+							"qty": 5,
+							"rate": 100,
+							"warehouse": "_Test Warehouse - _TC",
+							"use_serial_batch_fields": 1,
+						}
+					],
+				}
+			)
+			dn.insert()
+			dn.submit()
+			dn.reload()
+
+			entries = frappe.get_all(
+				"Serial and Batch Entry",
+				filters={"parent": dn.items[0].serial_and_batch_bundle},
+				fields=["batch_no", "qty"],
+				order_by="idx",
+			)
+			self.assertEqual(len(entries), 2)
+			self.assertEqual(abs(entries[0].qty), 2)
+			self.assertEqual(abs(entries[1].qty), 3)
+		finally:
+			frappe.db.set_single_value("Stock Settings", "pick_serial_and_batch_based_on", original_based_on)
+			frappe.db.set_single_value(
+				"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", original_auto_create
+			)


### PR DESCRIPTION
  ### Issue
 - When automatic outward Serial and Batch Bundle creation is enabled, ERPNext can assign a single batch that cannot fulfil the complete row quantity.

-  The existing selection loop reduces the requested quantity while checking each batch and leaves the last visited batch assigned to the row.

 - This change assigns a batch only when the first eligible batch can fulfil the complete quantity. Otherwise, `batch_no` remains empty so the standard Serial and Batch Bundle process can split the quantity across batches.

  **Fixes** [#58640](https://github.com/frappe/erpnext/issues/58640)

  ### Steps to reproduce

  1. Open Stock Settings.
  2. Set **Pick Serial / Batch Bundle Based On** to `Expiry`.
  3. Enable **Auto Create Serial and Batch Bundle For Outward**.
  4. Create a batch-controlled item with the following stock:
     - HP-03: 2 units, expires first
     - HP-02: 3 units, expires next
     - HP-01: 14 units, expires last
  5. Create a Delivery Note for this item.
  6. Enter a quantity of 5.
  7. Submit the Delivery Note.

  ### Actual behaviour

-  When a Delivery Note is created for 5 units, ERPNext assigns only `HP-02` to the row, even though it contains just 3 units.

-  On submission, ERPNext attempts to take all 5 units from `HP-02`:  `3 available - 5 required = -2`

-  This raises a misleading batch negative-stock error and ignores the 2 units available in `HP-03`.

 - The same problem occurs when the requested quantity exceeds the total available stock. For example, when requesting 30 units while only 19 are available, ERPNext assigns an individual batch that cannot fulfil the quantity.

  ### Expected behaviour

-  For a Delivery Note of 5 units, ERPNext should leave the row's `batch_no` empty and allow the automatically created Serial and Batch Bundle to split the quantity in FEFO order:

  - HP-03: 2 units
  - HP-02: 3 units
  - Total: 5 units

 - A batch should be assigned directly only when that batch can fulfil the complete row quantity.

  - If the requested quantity is 30 while only 19 units are available across all batches, ERPNext should report insufficient stock instead of assigning an individual batch that cannot fulfil the quantity.

  ### Backport needed for V16